### PR TITLE
fix scope for ScalaTest dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   object Libraries {
     lazy val catsEffect   = "org.typelevel" %% "cats-effect" % Versions.catsEffect
-    lazy val scalaTest    = "org.scalatest" %% "scalatest"   % Versions.scalaTest
+    lazy val scalaTest    = "org.scalatest" %% "scalatest"   % Versions.scalaTest  % Test
   }
 
 }


### PR DESCRIPTION
Moves ScalaTest to the test scope (ScalaTest is 7MB in size on its own).

If ScalaTest is not used for testing, this will actually lead to issues apart from bloat (for example with µTest, `testOnly` does no longer work, as the command is intercepted by ScalaTest). In this case, one can simply exclude the ScalaTest dependency; but this tiny PR fixes the underlying issue.

Thanks for this nice utility library!