### PR TITLE
Propose an implicit val for the default instance for `Console[IO]` to the user

### DIFF
--- a/core/src/main/scala/cats/effect/Console.scala
+++ b/core/src/main/scala/cats/effect/Console.scala
@@ -74,4 +74,8 @@ object Console {
     * Default instance for `Console[IO]` that prints to standard input/output streams.
     */
   val io: Console[IO] = SyncConsole.stdio[IO]
+
+  object implicits {
+    implicit val instance: Console[IO] = io
+  }
 }

--- a/core/src/main/scala/cats/effect/Console.scala
+++ b/core/src/main/scala/cats/effect/Console.scala
@@ -76,6 +76,6 @@ object Console {
   val io: Console[IO] = SyncConsole.stdio[IO]
 
   object implicits {
-    implicit val instance: Console[IO] = io
+    implicit val ioConsole: Console[IO] = io
   }
 }


### PR DESCRIPTION
Hi @gvolpe,

While working on the update of `advanced-http4s`, I remarked that you don't propose an implicit val for the default instance of `Console[IO]`.

It's useful when you work with code like this:

```
  def stream[F[_]: Console]: F[Unit] = ...

  override def run(args: List[String]): IO[ExitCode] = {
    import cats.effect.Console.implicits._

    stream[IO].as(ExitCode.Success)
  }
```

WDYT ?